### PR TITLE
Potential fix for code scanning alert no. 52: Incomplete string escaping or encoding

### DIFF
--- a/src/commands/instances/prefijo.ts
+++ b/src/commands/instances/prefijo.ts
@@ -57,7 +57,7 @@ const command = new Command('prefijo', flags)
 		const pfpair =
 			(await PrefixPairModel.findOne(guildsearch)) || new PrefixPairModel(guildsearch);
 		const regex = new RegExp(
-			`^${prefix.replace(/[a-z]/g, (l) => `[${l.toUpperCase()}${l}]`).replace('\\', '\\\\')}[\n ]*`,
+			`^${prefix.replace(/[a-z]/g, (l) => `[${l.toUpperCase()}${l}]`).replace(/\\/g, '\\\\')}[\n ]*`,
 		);
 		prefixes[request.guildId] = {
 			// biome-ignore lint/suspicious/noAssignInExpressions: Asignación múltiple


### PR DESCRIPTION
Potential fix for [https://github.com/PapitaConPure/bot-de-pure/security/code-scanning/52](https://github.com/PapitaConPure/bot-de-pure/security/code-scanning/52)

La corrección mínima y más segura sin cambiar la funcionalidad actual es hacer que el reemplazo de backslash sea global.

**Cambio recomendado (único):**
- En `src/commands/instances/prefijo.ts`, línea del `new RegExp(...)`, cambiar:
  - `.replace('\\', '\\\\')`
  - por
  - `.replace(/\\/g, '\\\\')`

Así se escapan **todas** las barras invertidas del prefijo antes de construir la regex, manteniendo intacta la lógica existente de manejo de letras y del sufijo `[\n ]*`.

No hace falta agregar imports, métodos nuevos ni dependencias.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
