### PR TITLE
Potential fix for code scanning alert no. 53: Inefficient regular expression

### DIFF
--- a/src/systems/converters/boorutato.ts
+++ b/src/systems/converters/boorutato.ts
@@ -14,7 +14,7 @@ export const acceptedBoorutatoConverters =  ['gelbooru'] as const;
 export type AcceptedBoorutatoConverterKey = (typeof acceptedBoorutatoConverters)[number];
 
 const gelbooruPostRegex =
-	/(?<st>(?:<|\|\|){0,2}) ?(?<original>(?:(?:http:\/\/|https:\/\/))?(?:www\.)?gelbooru.com\/index\.php\?page=post(?:&\S*)*&id=(?<id>[0-9]+)(?:&\S*)?) ?(?<ed>(?:>|\|\|){0,2})/gi;
+	/(?<st>(?:<|\|\|){0,2}) ?(?<original>(?:(?:http:\/\/|https:\/\/))?(?:www\.)?gelbooru.com\/index\.php\?page=post(?:&[^\s&]*)*&id=(?<id>[0-9]+)(?:&[^\s&]*)?) ?(?<ed>(?:>|\|\|){0,2})/gi;
 
 /**
  * @description Detecta enlaces de Gelbooru en un mensaje y los reenvía con un Embed corregido, a través de una respuesta.

--- a/src/systems/converters/boorutato.ts
+++ b/src/systems/converters/boorutato.ts
@@ -14,7 +14,7 @@ export const acceptedBoorutatoConverters =  ['gelbooru'] as const;
 export type AcceptedBoorutatoConverterKey = (typeof acceptedBoorutatoConverters)[number];
 
 const gelbooruPostRegex =
-	/(?<st>(?:<|\|\|){0,2}) ?(?<original>(?:(?:http:\/\/|https:\/\/))?(?:www\.)?gelbooru.com\/index\.php\?page=post(?:&[^\s&]*=[^\s&]*)*&id=(?<id>[0-9]+)(?:&[^\s&]*=[^\s&]*)*) ?(?<ed>(?:>|\|\|){0,2})/gi;
+	/(?<st>(?:<|\|\|){0,2}) ?(?<original>(?:(?:http:\/\/|https:\/\/))?(?:www\.)?gelbooru.com\/index\.php\?page=post(?:&[^\s&=]+=[^\s&=]+)*&id=(?<id>[0-9]+)(?:&[^\s&=]+=[^\s&=]+)*) ?(?<ed>(?:>|\|\|){0,2})/gi;
 
 /**
  * @description Detecta enlaces de Gelbooru en un mensaje y los reenvía con un Embed corregido, a través de una respuesta.

--- a/src/systems/converters/boorutato.ts
+++ b/src/systems/converters/boorutato.ts
@@ -14,7 +14,7 @@ export const acceptedBoorutatoConverters =  ['gelbooru'] as const;
 export type AcceptedBoorutatoConverterKey = (typeof acceptedBoorutatoConverters)[number];
 
 const gelbooruPostRegex =
-	/(?<st>(?:<|\|\|){0,2}) ?(?<original>(?:(?:http:\/\/|https:\/\/))?(?:www\.)?gelbooru.com\/index\.php\?page=post(?:&[^\s&]*)*&id=(?<id>[0-9]+)(?:&[^\s&]*)?) ?(?<ed>(?:>|\|\|){0,2})/gi;
+	/(?<st>(?:<|\|\|){0,2}) ?(?<original>(?:(?:http:\/\/|https:\/\/))?(?:www\.)?gelbooru.com\/index\.php\?page=post(?:&[^\s&]*=[^\s&]*)*&id=(?<id>[0-9]+)(?:&[^\s&]*=[^\s&]*)*) ?(?<ed>(?:>|\|\|){0,2})/gi;
 
 /**
  * @description Detecta enlaces de Gelbooru en un mensaje y los reenvía con un Embed corregido, a través de una respuesta.


### PR DESCRIPTION
Potential fix for [https://github.com/PapitaConPure/bot-de-pure/security/code-scanning/53](https://github.com/PapitaConPure/bot-de-pure/security/code-scanning/53)

General fix: remove ambiguity between the delimiter `&` and the repeated token content by ensuring the inner repetition cannot consume `&`.  
Best fix here: replace each `\S*` that follows `&` with `[^\\s&]*`. This preserves intent (“non-whitespace query chars”) while preventing the inner token from swallowing `&`, eliminating the catastrophic partitioning risk.

In `src/systems/converters/boorutato.ts`, edit the regex on line 17:
- `(?:&\S*)*` → `(?:&[^\s&]*)*`
- trailing `(?:&\S*)?` → `(?:&[^\s&]*)?`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
